### PR TITLE
Change menu name from SIM settings to PIN settings

### DIFF
--- a/MoppApp/MoppApp/en.lproj/Localizable.strings
+++ b/MoppApp/MoppApp/en.lproj/Localizable.strings
@@ -4,7 +4,7 @@
 // TabBar
 "tab-containers" = "Documents";
 "tab-my-eid" = "My eID";
-"tab-sim-settings" = "SIM settings";
+"tab-sim-settings" = "PIN settings";
 "tab-settings" = "Settings";
 
 // *** Actions ***

--- a/MoppApp/MoppApp/et.lproj/Localizable.strings
+++ b/MoppApp/MoppApp/et.lproj/Localizable.strings
@@ -4,7 +4,7 @@
 // TabBar
 "tab-containers" = "Dokumendid";
 "tab-my-eid" = "Minu eID";
-"tab-sim-settings" = "SIM'i toimingud";
+"tab-sim-settings" = "PIN toimingud";
 "tab-settings" = "Sätted";
 
 // *** Actions ***


### PR DESCRIPTION
Someone should also take care of the autogenerated variable names in Localizations.h, Localizations.m  and  PinOperationsViewController.m 