### PR TITLE
* Fixed: pinning check assumes at least one certificate always exists

### DIFF
--- a/MoppLib/MoppLibNetworkManager.m
+++ b/MoppLib/MoppLibNetworkManager.m
@@ -119,8 +119,9 @@
 
 - (BOOL)certificatePinningCheckedWith:(NSURLAuthenticationChallenge *)challenge {
     SecTrustRef serverTrust = challenge.protectionSpace.serverTrust;
+    if (SecTrustGetCertificateCount(serverTrust) == 0)
+        return YES;
     SecCertificateRef certificate = SecTrustGetCertificateAtIndex(serverTrust, 0);
-
     NSMutableArray *policies = [NSMutableArray array];
     [policies addObject:(__bridge_transfer id)SecPolicyCreateSSL(true, (__bridge CFStringRef)challenge.protectionSpace.host)];
     SecTrustSetPolicies(serverTrust, (__bridge CFArrayRef)policies);


### PR DESCRIPTION
MOPPIOS-541

Signed-off-by: Sander Hunt <sander.hunt@fob-solutions.com>