### PR TITLE
Search LDAP by company name if string is 4 digits or less.

### DIFF
--- a/CryptoLib/CryptoLib/Ldap/OpenLdap.swift
+++ b/CryptoLib/CryptoLib/Ldap/OpenLdap.swift
@@ -103,7 +103,7 @@ public class OpenLdap {
 
         let filter = if isPersonalCode(escapedIdentityCode) {
             "(serialNumber=\(secureLdap ? "PNOEE-" : "")\(escapedIdentityCode))"
-        } else if escapedIdentityCode.rangeOfCharacter(from: CharacterSet.decimalDigits.inverted) == nil {
+        } else if escapedIdentityCode.count > 4 && escapedIdentityCode.rangeOfCharacter(from: CharacterSet.decimalDigits.inverted) == nil {
             "(serialNumber=\(escapedIdentityCode))"
         } else {
             "(cn=*\(escapedIdentityCode)*)"


### PR DESCRIPTION
**MOPPIOS-1210** 

- Search LDAP by company name if string is 4 digits or less.

Signed-off-by: Boriss Melikjan <boriss.melikjan@nortal.com>
